### PR TITLE
Install ROOT from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN true \
         libXrandr-devel libXinerama-devel libXcursor-devel \
         libjpeg-devel libpng-devel \
         mesa-libGLU-devel \
+	cfitsio-devel mysql-devel postgresql-devel sqlite-devel\
     && provisioning/install-sw.sh root 6.24.06 /opt/root
 
 # Required for ROOT Jupyter kernel:

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,16 @@ RUN true \
     && yum install -y devtoolset-8
 
 
+# Install additional LEGEND software build dependencies:
+
+RUN yum install -y \
+    libcurl-devel \
+    boost-devel \
+    zeromq-devel \
+    gsl-devel fftw-devel \
+    libxml2-devel
+
+
 # Install HDF5:
 
 COPY provisioning/install-sw-scripts/hdf5-* provisioning/install-sw-scripts/
@@ -114,15 +124,6 @@ RUN yum install -y \
     pwgen apg \
     xterm rxvt-unicode st \
     https://download.opensuse.org/repositories/home:/rabin-io/CentOS_7/x86_64/mlterm-3.9.0-8.3.x86_64.rpm
-
-
-# Install additional LEGEND software build dependencies:
-
-RUN yum install -y \
-    libcurl-devel \
-    boost-devel \
-    zeromq-devel \
-    gsl-devel fftw-devel
 
 
 # Install Snakemake and panoptes-ui

--- a/provisioning/install-sw-scripts/root-setup.sh
+++ b/provisioning/install-sw-scripts/root-setup.sh
@@ -2,26 +2,27 @@
 #
 # Copyright (c) 2016: Oliver Schulz.
 
+DEFAULT_BUILD_OPTS="-Dminuit2=ON"
 
 pkg_install() {
-    DOWNLOAD_URL=""
-    if [ "${LINUX_DIST_BINCOMPAT}" = "ubuntu-14.04" ] ; then
-        DOWNLOAD_URL="https://root.cern.ch/download/root_v${PACKAGE_VERSION}.Linux-ubuntu14-x86_64-gcc4.8.tar.gz"
-    elif [ "${LINUX_DIST_BINCOMPAT}" = "ubuntu-16.04" ] ; then
-        DOWNLOAD_URL="https://root.cern.ch/download/root_v${PACKAGE_VERSION}.Linux-ubuntu16-x86_64-gcc5.4.tar.gz"
-    elif [ "${LINUX_DIST_BINCOMPAT}" = "rhel-6" ] ; then
-        DOWNLOAD_URL="https://root.cern.ch/download/root_v${PACKAGE_VERSION}.Linux-slc6-x86_64-gcc4.4.tar.gz"
-    elif [ "${LINUX_DIST_BINCOMPAT}" = "rhel-7" ] ; then
-        DOWNLOAD_URL="https://root.cern.ch/download/root_v${PACKAGE_VERSION}.Linux-centos7-x86_64-gcc4.8.tar.gz"
-    else
-        echo "ERROR: Unsupported Linux distribution (binary compatible) \"${LINUX_DIST_BINCOMPAT}\"".
-        exit 1
-    fi
+    source disable-conda.sh
+    scl enable devtoolset-8 bash
+    
+    DOWNLOAD_URL="https://root.cern/download/root_v${PACKAGE_VERSION}.source.tar.gz"
     echo "INFO: Download URL: \"${DOWNLOAD_URL}\"." >&2
 
+    mkdir src build
     mkdir -p "${INSTALL_PREFIX}"
-    download "${DOWNLOAD_URL}" \
-        | tar --strip-components=1 -x -z -f - -C "${INSTALL_PREFIX}"
+    download "${DOWNLOAD_URL}" | tar --strip-components 1 -C src --strip=1 -x -z
+    cd build
+    
+    cmake \
+	 -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+	 -DPython3_ROOT_DIR=${CONDA_PREFIX}/bin \
+	 ${DEFAULT_BUILD_OPTS} \
+	 ../src
+    
+    time make -j"$(nproc)" install
 }
 
 

--- a/provisioning/install-sw-scripts/root-setup.sh
+++ b/provisioning/install-sw-scripts/root-setup.sh
@@ -2,11 +2,10 @@
 #
 # Copyright (c) 2016: Oliver Schulz.
 
-DEFAULT_BUILD_OPTS="-Dminuit2=ON"
+DEFAULT_BUILD_OPTS="-Dbuiltin_davix=ON -Dbuiltin_lzma=ON -Dbuiltin_pcre=ON -Dbuiltin_unuran=ON -Dbuiltin_vdt=ON -Dbuiltin_veccore=ON -Dbuiltin_zlib=ON -Dfortran=ON -Dminuit2=ON -Dshadowpw=ON -Dsoversion=ON -Dunuran=ON -Dvmc=ON"
 
 pkg_install() {
     source disable-conda.sh
-    scl enable devtoolset-8 bash
     
     DOWNLOAD_URL="https://root.cern/download/root_v${PACKAGE_VERSION}.source.tar.gz"
     echo "INFO: Download URL: \"${DOWNLOAD_URL}\"." >&2


### PR DESCRIPTION
I based the installation script heavily on the ones for Geant4 and CLHEP. In the end, building against Conda ended up being very difficult (as warned), so ROOT is installed against the centOS (with devtoolset-8) libraries, with the sole exception of python which uses conda. This makes pyROOT work, as far as I have tested it, and I have been able to install and run MGDO/MaGe/mage-post-proc against it. I also moved the "additional LEGEND software build dependencies" to the start of the container build since a few of those are prerequisites for useful ROOT addons.