### PR TITLE
Enable pip/conda interoperability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,8 @@ RUN mamba install -y \
     iminuit \
     numba
 
+# Enable interop between pip and conda
+RUN conda config --system --set pip_interop_enabled True
 
 # Install Xpra:
 


### PR DESCRIPTION
This will update the system conda config (`/opt/conda/.condarc`) to enable pip interoperability. As far as I can tell this just means adding `$HOME/.local/lib/python...` to the default python path unless this is overriddent by `$PYTHONUSERBASE`. This was the behavior we had with anaconda.